### PR TITLE
Polish NEBU UI: unify dark theme, shared components, and state copy

### DIFF
--- a/client/src/components/AuthDialog.tsx
+++ b/client/src/components/AuthDialog.tsx
@@ -9,24 +9,25 @@ export function AuthDialog({ children }: { children?: React.ReactNode }) {
         {children || (
           <Button variant="outline" className="gap-2">
             <Bot className="h-4 w-4" />
-            Sign In
+            Open Access
           </Button>
         )}
       </DialogTrigger>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-md border-white/15 bg-[#161925]/95 backdrop-blur-xl">
         <DialogHeader>
-          <DialogTitle>Connect your account</DialogTitle>
+          <p className="nebu-kicker">Operator Authentication</p>
+          <DialogTitle>Connect your control channel</DialogTitle>
           <DialogDescription>
-            Sign in with your preferred platform to access Stix Magic.
+            Authorize a platform below to unlock command routing and live session controls.
           </DialogDescription>
         </DialogHeader>
-        <div className="flex flex-col gap-4 py-4">
-          <Button className="w-full gap-2" size="lg" onClick={() => window.location.href = "/api/auth/zoom/init"}>
-            Sign in with Zoom
+        <div className="flex flex-col gap-3 py-4">
+          <Button className="w-full" size="lg" onClick={() => window.location.href = "/api/auth/zoom/init"}>
+            Continue with Zoom
           </Button>
           <Button className="w-full gap-2" variant="outline" size="lg" onClick={() => window.location.href = "/api/auth/telegram/init"}>
             <Bot className="h-4 w-4" />
-            Sign in with Telegram
+            Continue with Telegram
           </Button>
         </div>
       </DialogContent>

--- a/client/src/components/OnboardingModal.tsx
+++ b/client/src/components/OnboardingModal.tsx
@@ -15,7 +15,6 @@ export function OnboardingModal() {
   const [step, setStep] = useState(0);
 
   useEffect(() => {
-    // Show setup wizard if it hasn't been completed yet
     const hasSeen = localStorage.getItem("stixmagic_setup_complete");
     if (!hasSeen) {
       setOpen(true);
@@ -29,43 +28,41 @@ export function OnboardingModal() {
 
   const steps = [
     {
-      title: "Welcome to STIX MΛGIC ✨",
-      description: "Let's get your unified platform set up.",
-      icon: <Sparkles className="h-12 w-12 text-primary mx-auto mb-4" />,
+      title: "Welcome to NEBU Control",
+      description: "A short setup pass to bring your command stack online.",
+      icon: <Sparkles className="mx-auto mb-4 h-12 w-12 text-primary" />,
       content: (
-        <div className="space-y-4">
-          <p className="text-muted-foreground">
-            This quick wizard will help you configure your Telegram and Zoom integrations so you can start creating magic right away.
+        <div className="space-y-4 text-left">
+          <p className="text-sm text-muted-foreground">
+            You are two steps away from a live control loop. Connect your channels now so command routing and telemetry stay synchronized.
           </p>
         </div>
       )
     },
     {
-      title: "Connect Telegram 🤖",
-      description: "Link your BotFather token to enable Telegram features.",
-      icon: <Bot className="h-12 w-12 text-secondary mx-auto mb-4" />,
+      title: "Link Telegram",
+      description: "Attach your bot token for outbound command updates.",
+      icon: <Bot className="mx-auto mb-4 h-12 w-12 text-secondary" />,
       content: (
         <div className="space-y-4 text-left">
           <p className="text-sm text-muted-foreground">
-            1. Open @BotFather on Telegram and create a new bot.<br/>
-            2. Copy the HTTP API token.<br/>
-            3. Paste it below to link your bot securely.
+            Create a bot in @BotFather, copy the API token, then paste it below. We use this channel for alerts and command confirmations.
           </p>
           <div className="space-y-2">
-            <Input type="password" placeholder="e.g., 1234567890:ABCdefGhIJKlmNoPQRsTUVwxyZ" />
-            <p className="text-xs text-muted-foreground">This is saved securely to your environment.</p>
+            <Input type="password" placeholder="Telegram bot token" />
+            <p className="text-xs text-muted-foreground">Stored securely in your runtime environment.</p>
           </div>
         </div>
       )
     },
     {
-      title: "Zoom Integration 🎥",
-      description: "Optional: Enable live meeting controls.",
-      icon: <Settings className="h-12 w-12 text-accent mx-auto mb-4" />,
+      title: "Add Zoom access (optional)",
+      description: "Enable real-time room controls from this console.",
+      icon: <Settings className="mx-auto mb-4 h-12 w-12 text-accent" />,
       content: (
         <div className="space-y-4 text-left">
           <p className="text-sm text-muted-foreground">
-            Connect your Zoom OAuth App to enable automatic pinning, muting, and operator controls from the Nebulosa dashboard.
+            Connect your Zoom OAuth credentials to unlock admit, mute, lock, and capture workflows directly from NEBU.
           </p>
           <div className="space-y-2">
             <Input placeholder="Zoom Client ID" />
@@ -75,13 +72,13 @@ export function OnboardingModal() {
       )
     },
     {
-      title: "You're All Set! 🎉",
-      description: "STIX MΛGIC is ready to use.",
-      icon: <CheckCircle2 className="h-12 w-12 text-green-500 mx-auto mb-4" />,
+      title: "Console ready",
+      description: "Your core channels are configured.",
+      icon: <CheckCircle2 className="mx-auto mb-4 h-12 w-12 text-emerald-400" />,
       content: (
-        <div className="space-y-4">
-          <p className="text-muted-foreground">
-            Your platform is configured. You can now use the Telegram bot or the Magic Studio to generate sticker packs.
+        <div className="space-y-4 text-left">
+          <p className="text-sm text-muted-foreground">
+            Setup is complete. You can now run command flows, monitor alerts, and control active sessions from one interface.
           </p>
         </div>
       )
@@ -90,9 +87,10 @@ export function OnboardingModal() {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="sm:max-w-md text-center p-6 border-primary/20 shadow-lg">
+      <DialogContent className="sm:max-w-md border-white/15 bg-[#161925]/95 p-6 text-center shadow-2xl backdrop-blur-xl">
         <DialogHeader>
-          <DialogTitle className="text-2xl mb-2">{steps[step].title}</DialogTitle>
+          <p className="nebu-kicker">Onboarding</p>
+          <DialogTitle className="mb-2 text-2xl">{steps[step].title}</DialogTitle>
           <DialogDescription className="text-base">
             {steps[step].description}
           </DialogDescription>
@@ -103,20 +101,19 @@ export function OnboardingModal() {
           {steps[step].content}
         </div>
 
-        <div className="flex justify-between items-center w-full mt-4">
+        <div className="mt-4 flex w-full items-center justify-between">
           <div className="flex gap-2">
             {steps.map((_, i) => (
               <div
                 key={i}
-                className={`h-2 w-2 rounded-full transition-colors ${i === step ? 'bg-primary' : 'bg-muted'}`}
+                className={`h-2 w-6 rounded-full transition-colors ${i === step ? "bg-primary" : "bg-white/10"}`}
               />
             ))}
           </div>
           <Button
-            className="font-bold tracking-wide"
-            onClick={() => step < steps.length - 1 ? setStep(s => s + 1) : handleComplete()}
+            onClick={() => step < steps.length - 1 ? setStep((s) => s + 1) : handleComplete()}
           >
-            {step < steps.length - 1 ? "Next Step" : "Finish Setup"}
+            {step < steps.length - 1 ? "Continue" : "Enter Console"}
             {step < steps.length - 1 && <ArrowRight className="ml-2 h-4 w-4" />}
           </Button>
         </div>

--- a/client/src/components/ui/badge.tsx
+++ b/client/src/components/ui/badge.tsx
@@ -3,16 +3,16 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold tracking-wide transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
-        default: "border-transparent bg-primary text-primary-foreground",
-        secondary: "border-transparent bg-secondary text-secondary-foreground",
-        destructive: "border-transparent bg-destructive text-destructive-foreground",
-        outline: "text-foreground",
-        success: "border-transparent bg-green-100 text-green-800",
-        warning: "border-transparent bg-yellow-100 text-yellow-800",
+        default: "border-primary/30 bg-primary/15 text-primary",
+        secondary: "border-white/15 bg-white/[0.06] text-foreground",
+        destructive: "border-red-500/30 bg-red-500/15 text-red-300",
+        outline: "border-white/15 text-muted-foreground",
+        success: "border-emerald-500/25 bg-emerald-500/15 text-emerald-300",
+        warning: "border-amber-500/30 bg-amber-500/15 text-amber-300",
       },
     },
     defaultVariants: {

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -4,15 +4,15 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: "bg-primary text-primary-foreground shadow-[0_8px_18px_rgba(47,146,255,0.35)] hover:bg-primary/90 hover:shadow-[0_10px_24px_rgba(47,146,255,0.4)]",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        outline: "border border-white/15 bg-white/[0.03] text-foreground hover:bg-white/[0.08]",
+        secondary: "bg-secondary/85 text-secondary-foreground hover:bg-secondary",
+        ghost: "text-muted-foreground hover:bg-white/[0.05] hover:text-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
@@ -38,13 +38,7 @@ export interface ButtonProps
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
-    return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      />
-    );
+    return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
   },
 );
 Button.displayName = "Button";

--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ const Card = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
+    className={cn("nebu-panel text-card-foreground", className)}
     {...props}
   />
 ));
@@ -27,7 +27,7 @@ const CardTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <h3
     ref={ref}
-    className={cn("text-2xl font-semibold leading-none tracking-tight", className)}
+    className={cn("text-xl font-semibold leading-tight tracking-tight", className)}
     {...props}
   />
 ));

--- a/client/src/components/ui/feedback.tsx
+++ b/client/src/components/ui/feedback.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from "react";
-import { AlertCircle, CheckCircle2, Sparkles, RefreshCw } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { AlertCircle, CheckCircle2, Sparkles } from "lucide-react";
 
 interface FeedbackProps {
   type: "success" | "error" | "empty";
@@ -10,39 +9,26 @@ interface FeedbackProps {
 }
 
 export function Feedback({ type, title, description, action }: FeedbackProps) {
-  if (type === "error") {
-    return (
-      <div className="flex flex-col items-center justify-center py-20 gap-4 text-center">
-        <AlertCircle className="w-12 h-12 text-destructive mb-2" />
-        <h3 className="text-xl font-medium">{title}</h3>
-        {description && <p className="text-muted-foreground max-w-md">{description}</p>}
-        {action && <div className="mt-4">{action}</div>}
-      </div>
-    );
-  }
+  const iconMap = {
+    error: <AlertCircle className="h-8 w-8 text-destructive" />,
+    empty: <Sparkles className="h-8 w-8 text-primary" />,
+    success: <CheckCircle2 className="h-8 w-8 text-emerald-400" />,
+  };
 
-  if (type === "empty") {
-    return (
-      <div className="flex flex-col items-center justify-center py-20 gap-4 text-center">
-        <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center mb-2">
-          <Sparkles className="w-8 h-8 text-primary" />
-        </div>
-        <h3 className="text-xl font-medium">{title}</h3>
-        {description && <p className="text-muted-foreground max-w-md mx-auto">{description}</p>}
-        {action && <div className="mt-4">{action}</div>}
-      </div>
-    );
-  }
+  const surfaceTone = {
+    error: "border-red-500/20 bg-red-500/10",
+    empty: "border-primary/20 bg-primary/10",
+    success: "border-emerald-500/20 bg-emerald-500/10",
+  };
 
-  // success
   return (
-    <div className="flex flex-col items-center justify-center py-20 gap-4 text-center">
-      <div className="w-16 h-16 rounded-full bg-green-500/10 flex items-center justify-center mb-2">
-        <CheckCircle2 className="w-8 h-8 text-green-500" />
+    <div className="mx-auto flex w-full max-w-xl flex-col items-center justify-center gap-4 rounded-2xl border border-white/10 bg-card/70 px-6 py-14 text-center">
+      <div className={`flex h-14 w-14 items-center justify-center rounded-full border ${surfaceTone[type]}`}>
+        {iconMap[type]}
       </div>
-      <h3 className="text-xl font-medium">{title}</h3>
-      {description && <p className="text-muted-foreground max-w-md mx-auto">{description}</p>}
-      {action && <div className="mt-4">{action}</div>}
+      <h3 className="text-xl font-semibold tracking-tight">{title}</h3>
+      {description && <p className="max-w-md text-sm text-muted-foreground">{description}</p>}
+      {action && <div className="mt-2">{action}</div>}
     </div>
   );
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -3,54 +3,54 @@
 @tailwind utilities;
 
 :root {
-  --background: hsl(0, 0%, 100%);
-  --foreground: hsl(240, 10%, 3.9%);
-  --muted: hsl(240, 4.8%, 95.9%);
-  --muted-foreground: hsl(240, 3.7%, 45.9%);
-  --popover: hsl(0, 0%, 100%);
-  --popover-foreground: hsl(240, 10%, 3.9%);
-  --card: hsl(0, 0%, 100%);
-  --card-foreground: hsl(240, 10%, 3.9%);
-  --border: hsl(240, 5.9%, 90%);
-  --input: hsl(240, 5.9%, 90%);
-  --primary: hsl(207, 90%, 54%);
-  --primary-foreground: hsl(211, 100%, 99%);
-  --secondary: hsl(276, 80%, 58%);
-  --secondary-foreground: hsl(276, 20%, 98%);
-  --accent: hsl(151, 55%, 41.5%);
-  --accent-foreground: hsl(151, 20%, 98%);
-  --destructive: hsl(0, 84.2%, 60.2%);
-  --destructive-foreground: hsl(60, 9.1%, 97.8%);
-  --ring: hsl(240, 10%, 3.9%);
-  --radius: 0.75rem;
-  --success: hsl(151, 55%, 41.5%);
-  --warning: hsl(38, 92%, 50%);
-  --error: hsl(0, 84.2%, 60.2%);
+  --background: 228 28% 7%;
+  --foreground: 220 20% 94%;
+  --muted: 228 22% 13%;
+  --muted-foreground: 218 14% 68%;
+  --popover: 228 26% 9%;
+  --popover-foreground: 220 20% 94%;
+  --card: 228 24% 12%;
+  --card-foreground: 220 20% 94%;
+  --border: 0 0% 100% / 0.08;
+  --input: 225 18% 18%;
+  --primary: 206 92% 58%;
+  --primary-foreground: 210 100% 98%;
+  --secondary: 266 62% 64%;
+  --secondary-foreground: 266 85% 10%;
+  --accent: 196 88% 57%;
+  --accent-foreground: 210 100% 98%;
+  --destructive: 0 74% 58%;
+  --destructive-foreground: 0 0% 98%;
+  --ring: 206 92% 58%;
+  --radius: 0.9rem;
+  --success: 151 60% 45%;
+  --warning: 38 92% 54%;
+  --error: 0 74% 58%;
 }
 
 .dark {
-  --background: hsl(240, 10%, 3.9%);
-  --foreground: hsl(0, 0%, 98%);
-  --muted: hsl(240, 3.7%, 15.9%);
-  --muted-foreground: hsl(240, 5%, 64.9%);
-  --popover: hsl(240, 10%, 3.9%);
-  --popover-foreground: hsl(0, 0%, 98%);
-  --card: hsl(240, 10%, 3.9%);
-  --card-foreground: hsl(0, 0%, 98%);
-  --border: hsl(240, 3.7%, 15.9%);
-  --input: hsl(240, 3.7%, 15.9%);
-  --primary: hsl(207, 90%, 54%);
-  --primary-foreground: hsl(211, 100%, 99%);
-  --secondary: hsl(276, 80%, 58%);
-  --secondary-foreground: hsl(276, 20%, 98%);
-  --accent: hsl(151, 55%, 41.5%);
-  --accent-foreground: hsl(151, 20%, 98%);
-  --destructive: hsl(0, 62.8%, 30.6%);
-  --destructive-foreground: hsl(0, 0%, 98%);
-  --ring: hsl(240, 4.9%, 83.9%);
-  --success: hsl(151, 55%, 41.5%);
-  --warning: hsl(38, 92%, 50%);
-  --error: hsl(0, 62.8%, 30.6%);
+  --background: 228 28% 7%;
+  --foreground: 220 20% 94%;
+  --muted: 228 22% 13%;
+  --muted-foreground: 218 14% 68%;
+  --popover: 228 26% 9%;
+  --popover-foreground: 220 20% 94%;
+  --card: 228 24% 12%;
+  --card-foreground: 220 20% 94%;
+  --border: 0 0% 100% / 0.08;
+  --input: 225 18% 18%;
+  --primary: 206 92% 58%;
+  --primary-foreground: 210 100% 98%;
+  --secondary: 266 62% 64%;
+  --secondary-foreground: 266 85% 10%;
+  --accent: 196 88% 57%;
+  --accent-foreground: 210 100% 98%;
+  --destructive: 0 74% 58%;
+  --destructive-foreground: 0 0% 98%;
+  --ring: 206 92% 58%;
+  --success: 151 60% 45%;
+  --warning: 38 92% 54%;
+  --error: 0 74% 58%;
 }
 
 @layer base {
@@ -60,37 +60,24 @@
 
   body {
     @apply font-sans antialiased bg-background text-foreground;
+    background-image:
+      radial-gradient(circle at 15% -10%, rgba(57, 157, 255, 0.12), transparent 35%),
+      radial-gradient(circle at 85% -25%, rgba(165, 118, 255, 0.1), transparent 38%),
+      linear-gradient(180deg, #11131a 0%, #161925 100%);
+    min-height: 100vh;
   }
 }
 
-@layer utilities {
-  .gradient-bg {
-    background: linear-gradient(135deg, hsl(207, 90%, 54%) 0%, hsl(276, 80%, 58%) 100%);
+@layer components {
+  .nebu-panel {
+    @apply rounded-xl border border-white/10 bg-card/80 backdrop-blur-md;
+    box-shadow: 0 12px 34px rgba(5, 9, 20, 0.4);
   }
 
-  .glass-effect {
-    backdrop-filter: blur(10px);
-    background: rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-  }
-
-  .status-indicator {
-    @apply w-2 h-2 rounded-full animate-pulse;
-  }
-
-  .status-online {
-    @apply bg-green-500;
-  }
-
-  .status-offline {
-    @apply bg-red-500;
-  }
-
-  .status-warning {
-    @apply bg-yellow-500;
+  .nebu-kicker {
+    @apply text-[11px] uppercase tracking-[0.24em] text-muted-foreground;
   }
 }
-
 
 @keyframes xiPulseActive {
   0%,
@@ -117,7 +104,6 @@
     transform: scale(1.08);
   }
 }
-
 
 @layer utilities {
   .xi-pulse-active {

--- a/client/src/pages/nebulosa-dashboard.tsx
+++ b/client/src/pages/nebulosa-dashboard.tsx
@@ -91,7 +91,7 @@ export default function NebulosaDashboard() {
   const handleParsedCommand = async (rawCommand: string) => {
     const parsed = parseNebuCommand(rawCommand, sessionId);
     if (!parsed) {
-      setExpressLog((prev) => ["Unsupported command. Use /zoom admit all | /zoom mute all | /zoom lock room | /capture moment", ...prev].slice(0, 6));
+      setExpressLog((prev) => ["Command not recognized. Available: /zoom admit all · /zoom mute all · /zoom lock room · /capture moment", ...prev].slice(0, 6));
       return;
     }
 
@@ -120,10 +120,10 @@ export default function NebulosaDashboard() {
   if (sessionQuery.isError) {
     return (
       <div className="min-h-screen bg-background p-6">
-        <Card className="max-w-md mx-auto mt-16">
+        <Card className="mx-auto mt-16 max-w-md">
           <CardHeader>
             <CardTitle>Operator Login</CardTitle>
-            <CardDescription>Nebu command grid requires operator authentication.</CardDescription>
+            <CardDescription>Authenticate to restore command routing and session visibility.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
             <Input value={username} onChange={(e) => setUsername(e.target.value)} placeholder="username" />
@@ -138,12 +138,12 @@ export default function NebulosaDashboard() {
   }
 
   return (
-    <div className="min-h-screen bg-background text-foreground p-4 md:p-6">
-      <div className="max-w-7xl mx-auto space-y-4">
+    <div className="min-h-screen bg-background p-4 text-foreground md:p-6">
+      <div className="mx-auto max-w-7xl space-y-4">
         <header className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex items-center gap-3">
             <XiGlyph state="active" label="nebu" size={28} />
-            <h1 className="text-2xl font-bold">Nebu Host Control · Command-First</h1>
+            <h1 className="text-2xl font-semibold tracking-tight">NEBU Host Control</h1>
           </div>
           <div className="text-xs uppercase tracking-wider text-muted-foreground">
             {sessionQuery.data?.environment ?? "-"} · {sessionQuery.data?.operator.username ?? "guest"} · Telegram: {telegramStatusQuery.data?.active ? "Connected" : "Offline"}
@@ -167,12 +167,12 @@ export default function NebulosaDashboard() {
                     void handleParsedCommand(command);
                   }}
                   isExecuting={createCommandMutation.isPending}
-                  helperText="Supported: /zoom admit all · /zoom mute all · /zoom lock room · /capture moment"
+                  helperText="Available commands: /zoom admit all · /zoom mute all · /zoom lock room · /capture moment"
                 />
                 <div className="rounded-md border p-3">
                   <div className="text-sm font-medium mb-2">Express Feed</div>
                   <div className="space-y-1 text-xs text-muted-foreground">
-                    {expressLog.length === 0 ? <p>No outbound messages yet.</p> : expressLog.map((item, index) => <p key={`${item}-${index}`}>{item}</p>)}
+                    {expressLog.length === 0 ? <p>No outbound traffic yet. Execute a command to start the feed.</p> : expressLog.map((item, index) => <p key={`${item}-${index}`}>{item}</p>)}
                   </div>
                 </div>
               </CardContent>
@@ -204,6 +204,7 @@ export default function NebulosaDashboard() {
                 </CardHeader>
                 <CardContent className="grid md:grid-cols-2 gap-3">
                   <div className="space-y-2 max-h-72 overflow-auto">
+                    {sortedCommands.length === 0 && <p className="rounded-md border border-dashed border-white/15 p-3 text-xs text-muted-foreground">Queue is clear. New commands will appear here in real time.</p>}
                     {sortedCommands.slice(0, 12).map((command) => (
                       <div key={command.id} className="rounded-md border p-2 text-sm">
                         <div className="font-medium">{command.type}</div>
@@ -212,6 +213,7 @@ export default function NebulosaDashboard() {
                     ))}
                   </div>
                   <div className="space-y-2 max-h-72 overflow-auto">
+                    {(alertsQuery.data ?? []).length === 0 && <p className="rounded-md border border-dashed border-white/15 p-3 text-xs text-muted-foreground">No active alerts. The system is operating within expected thresholds.</p>}
                     {(alertsQuery.data ?? []).map((alert) => (
                       <div key={alert.id} className="rounded-md border p-2 text-sm">
                         <div className="font-medium">{alert.severity.toUpperCase()}</div>

--- a/client/src/pages/playground.tsx
+++ b/client/src/pages/playground.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Loader2, AlertCircle, CheckCircle2, Sparkles, LayoutGrid } from "lucide-react";
+import { Loader2, AlertCircle, CheckCircle2, LayoutGrid } from "lucide-react";
 import { Skeleton, CardSkeleton } from "@/components/ui/skeleton";
 import { Feedback } from "@/components/ui/feedback";
 
@@ -11,70 +11,51 @@ export default function Playground() {
   const [demoState, setDemoState] = useState<"idle" | "loading" | "success" | "error" | "empty">("idle");
 
   return (
-    <div className="min-h-screen bg-background text-foreground p-4 md:p-8 space-y-8">
-      <div className="max-w-6xl mx-auto space-y-8">
-        <header className="flex justify-between items-end border-b pb-4">
+    <div className="min-h-screen bg-background p-4 text-foreground md:p-8">
+      <div className="mx-auto max-w-6xl space-y-8">
+        <header className="flex flex-wrap items-end justify-between gap-4 border-b border-white/10 pb-4">
           <div>
-            <h1 className="text-3xl font-bold flex items-center gap-2">
-              <LayoutGrid className="w-8 h-8 text-primary" />
-              UI Playground
+            <p className="nebu-kicker">NEBU Visual Lab</p>
+            <h1 className="mt-1 flex items-center gap-2 text-3xl font-semibold tracking-tight">
+              <LayoutGrid className="h-8 w-8 text-primary" />
+              State Consistency Review
             </h1>
-            <p className="text-muted-foreground mt-2">A preview of visual system states used across the product.</p>
+            <p className="mt-2 max-w-2xl text-sm text-muted-foreground">Every major state used in the product, validated against a single visual and tonal system.</p>
           </div>
-          <div className="flex gap-2">
-            <Button
-              variant={globalLoading ? "destructive" : "outline"}
-              onClick={() => setGlobalLoading(!globalLoading)}
-            >
-              {globalLoading ? "Stop Global Loading" : "Simulate Global Loading"}
-            </Button>
-          </div>
+          <Button variant={globalLoading ? "destructive" : "outline"} onClick={() => setGlobalLoading(!globalLoading)}>
+            {globalLoading ? "Stop simulation" : "Simulate full-screen load"}
+          </Button>
         </header>
 
         {globalLoading ? (
-          <div className="py-20 flex flex-col items-center justify-center gap-4">
-            <Loader2 className="w-12 h-12 text-primary animate-spin" />
-            <p className="text-muted-foreground">Simulating full page load...</p>
+          <div className="nebu-panel flex flex-col items-center justify-center gap-4 py-20">
+            <Loader2 className="h-12 w-12 animate-spin text-primary" />
+            <p className="text-sm text-muted-foreground">Preparing control surfaces…</p>
           </div>
         ) : (
           <>
             <section className="space-y-4">
-              <div className="flex justify-between items-center border-b pb-2">
-                <h2 className="text-xl font-semibold">Interactive States Demo</h2>
-                <div className="flex gap-2 text-sm">
-                  <Badge
-                    variant={demoState === "idle" ? "default" : "outline"}
-                    className="cursor-pointer"
-                    onClick={() => setDemoState("idle")}
-                  >Idle</Badge>
-                  <Badge
-                    variant={demoState === "loading" ? "default" : "outline"}
-                    className="cursor-pointer"
-                    onClick={() => setDemoState("loading")}
-                  >Loading</Badge>
-                  <Badge
-                    variant={demoState === "success" ? "default" : "outline"}
-                    className="cursor-pointer"
-                    onClick={() => setDemoState("success")}
-                  >Success</Badge>
-                  <Badge
-                    variant={demoState === "error" ? "default" : "outline"}
-                    className="cursor-pointer"
-                    onClick={() => setDemoState("error")}
-                  >Error</Badge>
-                  <Badge
-                    variant={demoState === "empty" ? "default" : "outline"}
-                    className="cursor-pointer"
-                    onClick={() => setDemoState("empty")}
-                  >Empty</Badge>
+              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-2">
+                <h2 className="text-lg font-semibold">Interactive state module</h2>
+                <div className="flex flex-wrap gap-2 text-sm">
+                  {(["idle", "loading", "success", "error", "empty"] as const).map((state) => (
+                    <Badge
+                      key={state}
+                      variant={demoState === state ? "default" : "outline"}
+                      className="cursor-pointer capitalize"
+                      onClick={() => setDemoState(state)}
+                    >
+                      {state}
+                    </Badge>
+                  ))}
                 </div>
               </div>
 
-              <Card className="min-h-[300px] flex items-center justify-center border-dashed">
+              <Card className="min-h-[300px] border-dashed border-white/20 flex items-center justify-center">
                 {demoState === "idle" && (
-                  <div className="text-center space-y-4">
-                    <p className="text-muted-foreground">Select a state above to preview.</p>
-                    <Button onClick={() => setDemoState("loading")}>Start Action</Button>
+                  <div className="space-y-4 text-center">
+                    <p className="text-sm text-muted-foreground">Select a state to validate copy, spacing, and feedback rhythm.</p>
+                    <Button onClick={() => setDemoState("loading")}>Run demo flow</Button>
                   </div>
                 )}
 
@@ -91,45 +72,45 @@ export default function Playground() {
                 {demoState === "success" && (
                   <Feedback
                     type="success"
-                    title="Action Completed"
-                    description="The item was successfully processed and saved."
-                    action={<Button variant="outline" onClick={() => setDemoState("idle")}>Reset</Button>}
+                    title="Execution complete"
+                    description="The command package was processed and synced to active channels."
+                    action={<Button variant="outline" onClick={() => setDemoState("idle")}>Reset preview</Button>}
                   />
                 )}
 
                 {demoState === "error" && (
                   <Feedback
                     type="error"
-                    title="Failed to process"
-                    description="There was a problem connecting to the server. Please try again."
-                    action={<Button onClick={() => setDemoState("loading")}>Retry Action</Button>}
+                    title="Command path interrupted"
+                    description="Connection to the runtime API was lost. Retry when the channel stabilizes."
+                    action={<Button onClick={() => setDemoState("loading")}>Retry sequence</Button>}
                   />
                 )}
 
                 {demoState === "empty" && (
                   <Feedback
                     type="empty"
-                    title="No items found"
-                    description="There are currently no items matching your criteria. Try adjusting your filters or create a new one."
-                    action={<Button>Create New Item</Button>}
+                    title="No active records"
+                    description="There is no data in this view yet. Start by creating your first command run."
+                    action={<Button>Create command</Button>}
                   />
                 )}
               </Card>
             </section>
 
-            <div className="grid md:grid-cols-2 gap-8">
+            <div className="grid gap-8 md:grid-cols-2">
               <section className="space-y-4">
-                <h2 className="text-xl font-semibold border-b pb-2">Loading Components</h2>
+                <h2 className="border-b border-white/10 pb-2 text-lg font-semibold">Loading surfaces</h2>
                 <div className="space-y-4">
                   <Card>
                     <CardHeader>
-                      <CardTitle>Spinners</CardTitle>
+                      <CardTitle>Spinner behavior</CardTitle>
                     </CardHeader>
                     <CardContent className="flex items-center gap-6">
-                      <Loader2 className="w-8 h-8 animate-spin text-primary" />
-                      <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+                      <Loader2 className="h-8 w-8 animate-spin text-primary" />
+                      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                       <Button disabled>
-                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                         Processing
                       </Button>
                     </CardContent>
@@ -137,7 +118,7 @@ export default function Playground() {
 
                   <Card>
                     <CardHeader>
-                      <CardTitle>Skeletons</CardTitle>
+                      <CardTitle>Skeleton rhythm</CardTitle>
                     </CardHeader>
                     <CardContent className="space-y-4">
                       <div className="space-y-2">
@@ -157,64 +138,31 @@ export default function Playground() {
               </section>
 
               <section className="space-y-4">
-                <h2 className="text-xl font-semibold border-b pb-2">Feedback UI</h2>
+                <h2 className="border-b border-white/10 pb-2 text-lg font-semibold">Inline feedback</h2>
                 <div className="space-y-4">
-                  <div className="p-4 border rounded-lg bg-green-500/10 border-green-500/20 flex items-start gap-3">
-                    <CheckCircle2 className="w-5 h-5 text-green-500 mt-0.5" />
+                  <div className="flex items-start gap-3 rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-4">
+                    <CheckCircle2 className="mt-0.5 h-5 w-5 text-emerald-300" />
                     <div>
-                      <h3 className="font-medium text-green-700 dark:text-green-400">Success Alert</h3>
-                      <p className="text-sm text-green-600/80 dark:text-green-400/80">Inline success message styling.</p>
+                      <h3 className="font-medium text-emerald-200">Sync confirmed</h3>
+                      <p className="text-sm text-emerald-200/80">All active channels received the latest payload.</p>
                     </div>
                   </div>
 
-                  <div className="p-4 border rounded-lg bg-red-500/10 border-red-500/20 flex items-start gap-3">
-                    <AlertCircle className="w-5 h-5 text-red-500 mt-0.5" />
+                  <div className="flex items-start gap-3 rounded-lg border border-red-500/20 bg-red-500/10 p-4">
+                    <AlertCircle className="mt-0.5 h-5 w-5 text-red-300" />
                     <div>
-                      <h3 className="font-medium text-red-700 dark:text-red-400">Error Alert</h3>
-                      <p className="text-sm text-red-600/80 dark:text-red-400/80">Inline error message styling.</p>
+                      <h3 className="font-medium text-red-200">Action blocked</h3>
+                      <p className="text-sm text-red-200/80">The request was rejected by policy constraints.</p>
                     </div>
                   </div>
 
-                  <div className="p-4 border rounded-lg bg-yellow-500/10 border-yellow-500/20 flex items-start gap-3">
-                    <AlertCircle className="w-5 h-5 text-yellow-600 dark:text-yellow-500 mt-0.5" />
+                  <div className="flex items-start gap-3 rounded-lg border border-amber-500/20 bg-amber-500/10 p-4">
+                    <AlertCircle className="mt-0.5 h-5 w-5 text-amber-300" />
                     <div>
-                      <h3 className="font-medium text-yellow-800 dark:text-yellow-400">Warning Alert</h3>
-                      <p className="text-sm text-yellow-700/80 dark:text-yellow-400/80">Inline warning message styling.</p>
+                      <h3 className="font-medium text-amber-200">Operator check required</h3>
+                      <p className="text-sm text-amber-200/80">Review the queue before sending the next command wave.</p>
                     </div>
                   </div>
-                </div>
-              </section>
-
-              <section className="space-y-4">
-                <h2 className="text-xl font-semibold border-b pb-2">Status Badges</h2>
-                <div className="flex flex-wrap gap-4">
-                  <div className="space-y-2 text-center">
-                    <Badge variant="default">Default</Badge>
-                    <p className="text-xs text-muted-foreground">Primary Status</p>
-                  </div>
-                  <div className="space-y-2 text-center">
-                    <Badge variant="secondary">Secondary</Badge>
-                    <p className="text-xs text-muted-foreground">Neutral Status</p>
-                  </div>
-                  <div className="space-y-2 text-center">
-                    <Badge variant="outline">Outline</Badge>
-                    <p className="text-xs text-muted-foreground">Ghost Status</p>
-                  </div>
-                  <div className="space-y-2 text-center">
-                    <Badge variant="destructive">Destructive</Badge>
-                    <p className="text-xs text-muted-foreground">Error/Danger</p>
-                  </div>
-                </div>
-              </section>
-
-              <section className="space-y-4">
-                <h2 className="text-xl font-semibold border-b pb-2">Action Elements</h2>
-                <div className="flex flex-wrap gap-4 items-center">
-                  <Button variant="default">Primary Action</Button>
-                  <Button variant="secondary">Secondary Action</Button>
-                  <Button variant="outline">Outline Action</Button>
-                  <Button variant="ghost">Ghost Action</Button>
-                  <Button variant="destructive">Destructive</Button>
                 </div>
               </section>
             </div>


### PR DESCRIPTION
### Motivation
- Align the app with the NEBU dark, operator-console aesthetic by centralizing visual tokens and panel treatments. 
- Remove inconsistent component styling and repetitive copy so user-facing surfaces feel cohesive and intentional. 
- Improve clarity of empty/loading/success/error states and auth/onboarding flows while preserving existing routes and logic.

### Description
- Centralized theme and added reusable primitives by updating `client/src/index.css` with NEBU palette, layered background, and `.nebu-panel`/`.nebu-kicker` utilities. 
- Standardized shared UI primitives by refactoring `Button`, `Card`, and `Badge` in `client/src/components/ui/` to enforce consistent borders, glow, spacing, and focus behavior. 
- Reworked feedback surfaces in `client/src/components/ui/feedback.tsx` and normalized state demos in `client/src/pages/playground.tsx` to present unified success/error/empty visuals and copy. 
- Updated auth and onboarding flows (copy and dialog surfaces) and polished dashboard edge states in `client/src/components/AuthDialog.tsx`, `client/src/components/OnboardingModal.tsx`, and `client/src/pages/nebulosa-dashboard.tsx` to use concise NEBU tone and explicit empty-state messaging.

### Testing
- Ran a production client build with `npm run client:build`, which completed successfully. 
- No route or data-flow logic was changed and no automated unit tests were modified as part of this UI-only pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d4de059900832bbb066db2ff03c632)